### PR TITLE
feat(renovate): enable auto-merge for lock file maintenance PRs

### DIFF
--- a/renovate/src/default.jsonc
+++ b/renovate/src/default.jsonc
@@ -33,13 +33,19 @@
   "assignAutomerge": false,
   // Specific rules
   "packageRules": [
-    // Enable auto-merge and grouping on specific update types
+    // Auto-merge lock file maintenance without version constraint
+    {
+      "matchUpdateTypes": [
+        "lockFileMaintenance",
+      ],
+      "automerge": true,
+    },
+    // Enable auto-merge and grouping on stable dependency updates
     {
       "matchUpdateTypes": [
         "minor",
         "patch",
         "pin",
-        "lockFileMaintenance",
       ],
       "matchCurrentVersion": "!/^0\\./",
       "groupName": "all stable and non-major dependencies",


### PR DESCRIPTION
## Summary

Separate `lockFileMaintenance` into its own packageRule without the `matchCurrentVersion` restriction, enabling auto-merge for lock file maintenance PRs regardless of dependency version constraints.

## Changes

- Added a dedicated packageRule for `lockFileMaintenance` with `automerge: true`
- Removed `lockFileMaintenance` from the grouped rule that had `matchCurrentVersion: "!/^0\\./"` restriction
- Updated comments to clarify the purpose of each rule

Lock file maintenance only refreshes existing versions in lock files without changing dependency versions, so it is safe to auto-merge unconditionally.

## Test plan

- [ ] Verify the GitHub Actions workflow builds and syncs to `renovate/main` branch
- [ ] Confirm the built `default.json` on `renovate/main` has the split rules
- [ ] Wait for Renovate to create the next lock maintenance PR and verify it shows "Automerge: Enabled by config"
